### PR TITLE
Adding support for doc-amd elements in validate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ Form-amd also depends on [doc-amd](https://github.com/elo7/doc-amd).
 ## Methods
 
 #### submitOnChange
-`.submitOnChange(selector[, callback])`
+`.submitOnChange(selectorOrDocElement[, callback])`
 
 ###### Description:
 Submit the parent form when event **change** is triggered.
 
 ###### Parameters:
-> selector: String //A CSS selector. Note that, if it is a class name with dots, the dots must be escaped. E.g.: doc(".my\\\\.class")
+> selectorOrDocElement: doc-amd object or String //A CSS selector. Note that, if it is a class name with dots, the dots must be escaped. E.g.: doc(".my\\\\.class")
 
 > callback: Function() //A function to call before the event is triggered
 
 ###### Sample:
 ``` js
 define(['form'], function(form) {
-  form.submitOnChange('#country'); //Submit the parent form when the country is selected
+  form.submitOnChange($('#country')); //Submit the parent form when the country is selected
   form.submitOnChange('#country', function(){...}); //Run the callback function and then submit the parent form when the country is selected
 });
 ```
@@ -72,20 +72,20 @@ define(['form'], function(form) {
 ```
 
 #### validate
-`.validate(selector[, object])`
+`.validate(selectorOrDocElement[, object])`
 
 ###### Description:
 Validate the form using almost all the html5 attributes validate spec.
 
 ###### Parameters:
-> selector: String
+> selectorOrDocElement: doc-amd object or String //A CSS selector. Note that, if it is a class name with dots, the dots must be escaped. E.g.: doc(".my\\\\.class")
 
 > object: Object //An object with the properties _messages_ ("required", "min", "maxlength", "pattern" or "email"), _success_ (function callback) or _error_ (function callback)
 
 ###### Sample:
 ``` js
 define(['form'], function(form) {
-  form.validate('#form'); //Validate the form with default messages
+  form.validate($('#form')); //Validate the form with default messages
   form.validate('#form', {
     messages: {
       'required': 'Field required.',

--- a/form.js
+++ b/form.js
@@ -23,10 +23,10 @@ define('form', ['doc'], function($) {
 	}
 
 	var appendMessage = function(label, message) {
-		if (label.find('.message').isEmpty()) {
+		if (label.find('.validation-message').isEmpty()) {
 			label.addClass('validation').addClass('error');
 			var messageTag = document.createElement('span');
-			$(messageTag).addClass('message');
+			$(messageTag).addClass('validation-message');
 
 			$(messageTag).text(message);
 			label.first().appendChild(messageTag);
@@ -44,7 +44,7 @@ define('form', ['doc'], function($) {
 
 	var removeValidationErrors = function(form) {
 		form.removeClass('has-errors');
-		form.find('.message').each(function(el) {
+		form.find('.validation-message').each(function(el) {
 			$(el).parent().removeClass('error');
 			$(el).removeItem();
 		});
@@ -141,7 +141,7 @@ define('form', ['doc'], function($) {
 				target.off('input', 'validationOff');
 				parent.removeClass('validation');
 				parent.removeClass('error');
-				parent.find('.message').removeItem();
+				parent.find('.validation-message').removeItem();
 			}, 'validationOff');
 		});
 	};

--- a/form.js
+++ b/form.js
@@ -224,7 +224,7 @@ define('form', ['doc'], function($) {
 			if (configs && configs.messages) {
 				validationMessages = configs.messages;
 			}
-			var $form = $(form);
+			var $form = toElements(form);
 			$form.attr('novalidate', true);
 			$form.throttle('submit', function() {
 				if (isValid.call(this, $form)) {

--- a/test/formTest.js.html
+++ b/test/formTest.js.html
@@ -133,19 +133,19 @@
 						form.validate('#formClearMessages');
 						$('#formClearMessages').trigger('submit');
 
-						assert.equal($('#label1').find('.message').isEmpty(), false);
-						assert.equal($('#label1').find('.message').text(), "This field is required");
-						assert.equal($('#label2').find('.message').isEmpty(), false);
-						assert.equal($('#label2').find('.message').text(), "Please enter a valid email address");
-						assert.equal($('#label3').find('.message').isEmpty(), false);
-						assert.equal($('#label3').find('.message').text(), "This field is required");
-						assert.equal($('#label4').find('.message').isEmpty(), false);
-						assert.equal($('#label4').find('.message').text(), "Please enter a value with max length less than or equal to 2");
-						assert.equal($('#label5').find('.message').isEmpty(), false);
-						assert.equal($('#label5').find('.message').text(), "Please enter a value greater than or equal to 3");
-						assert.equal($('#label6').find('.message').isEmpty(), false);
-						assert.equal($('#label6').find('.message').text(), "Please enter a valid value");
-						assert.equal($('#label7').find('.message').isEmpty(), true);
+						assert.equal($('#label1').find('.validation-message').isEmpty(), false);
+						assert.equal($('#label1').find('.validation-message').text(), "This field is required");
+						assert.equal($('#label2').find('.validation-message').isEmpty(), false);
+						assert.equal($('#label2').find('.validation-message').text(), "Please enter a valid email address");
+						assert.equal($('#label3').find('.validation-message').isEmpty(), false);
+						assert.equal($('#label3').find('.validation-message').text(), "This field is required");
+						assert.equal($('#label4').find('.validation-message').isEmpty(), false);
+						assert.equal($('#label4').find('.validation-message').text(), "Please enter a value with max length less than or equal to 2");
+						assert.equal($('#label5').find('.validation-message').isEmpty(), false);
+						assert.equal($('#label5').find('.validation-message').text(), "Please enter a value greater than or equal to 3");
+						assert.equal($('#label6').find('.validation-message').isEmpty(), false);
+						assert.equal($('#label6').find('.validation-message').text(), "Please enter a valid value");
+						assert.equal($('#label7').find('.validation-message').isEmpty(), true);
 					});
 
 					it('should insert error custom message for all elements', function(){
@@ -159,12 +159,12 @@
 						form.validate('#formClearMessages', {messages: messages});
 						$('#formClearMessages').trigger('submit');
 
-						assert.equal($('#label1').find('.message').text(), "Preencha este campo, por favor!");
-						assert.equal($('#label2').find('.message').text(), "Insira um e-mail válido, por favor!");
-						assert.equal($('#label3').find('.message').text(), "Preencha este campo, por favor!");
-						assert.equal($('#label4').find('.message').text(), "Insira no máximo 2 caracteres, por favor!");
-						assert.equal($('#label5').find('.message').text(), "Insira no mínimo 3 caracteres, por favor!");
-						assert.equal($('#label6').find('.message').text(), "Insira um valor válido, por favor!");
+						assert.equal($('#label1').find('.validation-message').text(), "Preencha este campo, por favor!");
+						assert.equal($('#label2').find('.validation-message').text(), "Insira um e-mail válido, por favor!");
+						assert.equal($('#label3').find('.validation-message').text(), "Preencha este campo, por favor!");
+						assert.equal($('#label4').find('.validation-message').text(), "Insira no máximo 2 caracteres, por favor!");
+						assert.equal($('#label5').find('.validation-message').text(), "Insira no mínimo 3 caracteres, por favor!");
+						assert.equal($('#label6').find('.validation-message').text(), "Insira um valor válido, por favor!");
 					});
 
 					it('should call success callback', function(){
@@ -194,14 +194,14 @@
 					it('should append message inside label', function(){
 						form.appendMessage('#labelAppendMessage', 'Teste');
 
-						assert.equal($('#labelAppendMessage').find('.message').isEmpty(), false);
+						assert.equal($('#labelAppendMessage').find('.validation-message').isEmpty(), false);
 					});
 
 					it('should append message inside label and remove the message when input event was dispatch', function(){
 						form.appendMessage('#labelAppendMessage', 'Teste');
 						$('#labelAppendMessage input').trigger('input');
 
-						assert.equal($('#labelAppendMessage').find('.message').isEmpty(), true);
+						assert.equal($('#labelAppendMessage').find('.validation-message').isEmpty(), true);
 					});
 
 					it('should remove all error messages', function(){
@@ -210,12 +210,12 @@
 
 						form.removeValidationErrors('#formClearMessages');
 
-						assert.equal($('#label1').find('.message').isEmpty(), true);
-						assert.equal($('#label2').find('.message').isEmpty(), true);
-						assert.equal($('#label3').find('.message').isEmpty(), true);
-						assert.equal($('#label4').find('.message').isEmpty(), true);
-						assert.equal($('#label5').find('.message').isEmpty(), true);
-						assert.equal($('#label6').find('.message').isEmpty(), true);
+						assert.equal($('#label1').find('.validation-message').isEmpty(), true);
+						assert.equal($('#label2').find('.validation-message').isEmpty(), true);
+						assert.equal($('#label3').find('.validation-message').isEmpty(), true);
+						assert.equal($('#label4').find('.validation-message').isEmpty(), true);
+						assert.equal($('#label5').find('.validation-message').isEmpty(), true);
+						assert.equal($('#label6').find('.validation-message').isEmpty(), true);
 					});
 				});
 			});


### PR DESCRIPTION
👍  @tisvasconcelos 

@AlineLee @luiz @mottam

## Changelog

- Adds support for receiving doc-amd objects in `validate` method
- Changes validation messages' class from `message` to `validation-message`